### PR TITLE
remove comm_info_request from base interpreter

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,6 @@ The easiest way to get started with a new kernel is to inherit from the base int
 - `inspect_request_impl`
 - `history_request_impl`
 - `is_complete_request_impl`
-- `comm_info_request_impl`
 
 as seen in the echo kernel provided as an example.
 
@@ -73,8 +72,6 @@ namespace echo_kernel
         xjson history_request_impl(const xhistory_arguments& args) override;
 
         xjson is_complete_request_impl(const std::string& code) override;
-
-        xjson comm_info_request_impl(const std::string& target_name) override;
 
         xjson kernel_info_request_impl() override;
 

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -4,8 +4,7 @@
 
    The full license is in the file LICENSE, distributed with this software.
 
-xeus
-====
+.. image:: http://quantstack.net/assets/images/xeus.svg
 
 C++ implementation of the Jupyter Kernel protocol
 
@@ -23,7 +22,13 @@ copyright on their contributions.
 This software is licensed under the BSD-3-Clause license. See the LICENSE file for details.
 
 .. toctree::
-   :maxdepth: 3
+   :caption: INSTALLATION
+   :maxdepth: 2
 
    installation
+
+.. toctree::
+   :caption: USAGE
+   :maxdepth: 2
+
    usage

--- a/docs/source/usage.rst
+++ b/docs/source/usage.rst
@@ -16,7 +16,6 @@ The easiest way to get started with a new kernel is to inherit from the base int
 - ``inspect_request_impl``
 - ``history_request_impl``
 - ``is_complete_request_impl``
-- ``comm_info_request_impl``
 - ``input_reply_impl``
 
 as seen in the echo kernel provided as an example.
@@ -58,8 +57,6 @@ as seen in the echo kernel provided as an example.
             xjson history_request_impl(const xhistory_arguments& args) override;
 
             xjson is_complete_request_impl(const std::string& code) override;
-
-            xjson comm_info_request_impl(const std::string& target_name) override;
 
             xjson kernel_info_request_impl() override;
 

--- a/example/echo_kernel/echo_interpreter.cpp
+++ b/example/echo_kernel/echo_interpreter.cpp
@@ -98,20 +98,6 @@ namespace echo_kernel
         return result;
     }
 
-    xjson echo_interpreter::comm_info_request_impl(const std::string& target_name)
-    {
-        std::cout << "Received comm_info_request" << std::endl;
-        std::cout << "target_name " << target_name << std::endl;
-        std::cout << std::endl;
-        xjson result;
-        std::string uid = xeus::new_xguid().to_string();
-        std::string snode_name = "/comms/" + uid + "/target_name";
-        char node_name[35];
-        std::copy(snode_name.begin(), snode_name.end(), node_name);
-        result.set_value(node_name, target_name);
-        return result;
-    }
-
     xjson echo_interpreter::kernel_info_request_impl()
     {
         xjson result;

--- a/example/echo_kernel/echo_interpreter.hpp
+++ b/example/echo_kernel/echo_interpreter.hpp
@@ -45,8 +45,6 @@ namespace echo_kernel
 
         xjson is_complete_request_impl(const std::string& code) override;
 
-        xjson comm_info_request_impl(const std::string& target_name) override;
-
         xjson kernel_info_request_impl() override;
 
         void input_reply_impl(const std::string& value) override;

--- a/include/xeus/xinterpreter.hpp
+++ b/include/xeus/xinterpreter.hpp
@@ -60,7 +60,6 @@ namespace xeus
 
         xjson history_request(const xhistory_arguments& args);
         xjson is_complete_request(const std::string& code);
-        xjson comm_info_request(const std::string& target_name);
         xjson kernel_info_request();
 
         // publish(msg_type, metadata, content) 
@@ -102,8 +101,6 @@ namespace xeus
         virtual xjson history_request_impl(const xhistory_arguments& args) = 0;
 
         virtual xjson is_complete_request_impl(const std::string& code) = 0;
-
-        virtual xjson comm_info_request_impl(const std::string& target_name) = 0;
 
         virtual xjson kernel_info_request_impl() = 0;
 

--- a/src/xinterpreter.cpp
+++ b/src/xinterpreter.cpp
@@ -53,11 +53,6 @@ namespace xeus
         return is_complete_request_impl(code);
     }
 
-    xjson xinterpreter::comm_info_request(const std::string& target_name)
-    {
-        return comm_info_request_impl(target_name);
-    }
-
     xjson xinterpreter::kernel_info_request()
     {
         return kernel_info_request_impl();

--- a/src/xkernel_core.cpp
+++ b/src/xkernel_core.cpp
@@ -241,7 +241,7 @@ namespace xeus
         const xjson& content = request.content();
         std::string target_name = content.get_string("/target_name", "");
 
-        xjson reply = p_interpreter->comm_info_request(target_name);
+        xjson reply;
         send_reply("comm_info_reply", xjson(), std::move(reply), c);
     }
 


### PR DESCRIPTION
The `xinterpreter` will not be responsible for the comm info requests.