### PR TITLE
xguid cleanup

### DIFF
--- a/example/echo_client/echo_client.cpp
+++ b/example/echo_client/echo_client.cpp
@@ -44,7 +44,7 @@ std::mutex cout_mutex;
           p_authentication(xeus::make_xauthentication(config.m_signature_scheme, config.m_key)),
           p_io_authentication(xeus::make_xauthentication(config.m_signature_scheme, config.m_key)),
           m_user_name(user_name),
-          m_session_id(xeus::xguid().to_string())
+          m_session_id(guid_to_hex(xeus::xguid()))
     {
         std::string sep = get_end_point(config.m_transport, config.m_ip, config.m_shell_port);
         m_shell.connect(sep);

--- a/example/echo_kernel/echo_interpreter.cpp
+++ b/example/echo_kernel/echo_interpreter.cpp
@@ -13,6 +13,10 @@
 namespace echo_kernel
 {
 
+    void echo_interpreter::configure_impl()
+    {
+    }
+
     xjson echo_interpreter::execute_request_impl(int execution_counter,
                                                  const std::string& code,
                                                  bool silent,

--- a/example/echo_kernel/echo_interpreter.hpp
+++ b/example/echo_kernel/echo_interpreter.hpp
@@ -27,6 +27,8 @@ namespace echo_kernel
 
     private:
 
+        void configure_impl() override;
+
         xjson execute_request_impl(int execution_counter,
                                    const std::string& code,
                                    bool silent,

--- a/include/xeus/xguid.hpp
+++ b/include/xeus/xguid.hpp
@@ -12,6 +12,7 @@
 #include <cstddef>
 #include <array>
 #include <string>
+#include <algorithm>
 
 #include "xeus.hpp"
 
@@ -21,6 +22,16 @@ namespace xeus
      * xguid declaration *
      *********************/
 
+    /**
+     * @class xguid
+     * @brief Globally unique identifier.
+     *
+     * Instances of xguid are stack allocated and implement a value semantics.
+     * Instances of xguid can be used as keys in std::map and std::unordered maps.
+     * The unique identifier is computed upon creation of the object, rebinding on
+     * the implementation of the operating system.
+     *
+     */
     class XEUS_API xguid
     {
     public:
@@ -29,38 +40,39 @@ namespace xeus
         using buffer_type = std::array<unsigned char, GUID_SIZE>;
 
         xguid();
-        xguid(const char* buffer);
-        const buffer_type& buffer() const noexcept;
-
-        std::string to_string() const noexcept;
 
         bool equal(const xguid& other) const noexcept;
+        bool lesser(const xguid& other) const noexcept;
 
     private:
 
+        xguid(const char*);
+
         buffer_type m_buffer;
+
+        friend XEUS_API std::string guid_to_hex(xguid uuid);
+        friend XEUS_API xguid hex_to_guid(const char* hex);
     };
 
     bool operator==(const xguid&, const xguid&);
     bool operator!=(const xguid&, const xguid&);
+    bool operator<(const xguid&, const xguid&);
+
+    XEUS_API std::string guid_to_hex(xguid uuid);
+    XEUS_API xguid hex_to_guid(const char* hex);
 
     /************************
      * xguid implementation *
      ************************/
 
-    inline xguid::xguid(const char* buffer)
-    {
-        std::copy(buffer, buffer + GUID_SIZE, m_buffer.begin());
-    }
-
-    inline const typename xguid::buffer_type& xguid::buffer() const noexcept
-    {
-        return m_buffer;
-    }
-
     inline bool xguid::equal(const xguid& other) const noexcept
     {
         return m_buffer == other.m_buffer;
+    }
+
+    inline bool xguid::lesser(const xguid& other) const noexcept
+    {
+        return std::lexicographical_compare(m_buffer.begin(), m_buffer.end(), other.m_buffer.begin(), other.m_buffer.end());
     }
 
     inline bool operator==(const xguid& lhs, const xguid& rhs)
@@ -71,6 +83,11 @@ namespace xeus
     inline bool operator!=(const xguid& lhs, const xguid& rhs)
     {
         return !lhs.equal(rhs);
+    }
+
+    inline bool operator<(const xguid& lhs, const xguid& rhs)
+    {
+        return lhs.lesser(rhs);
     }
 }
 

--- a/include/xeus/xinterpreter.hpp
+++ b/include/xeus/xinterpreter.hpp
@@ -12,6 +12,7 @@
 #include <string>
 #include <functional>
 #include <vector>
+
 #include "xeus.hpp"
 #include "xjson.hpp"
 
@@ -33,10 +34,9 @@ namespace xeus
 
     class XEUS_API xinterpreter
     {
-
     public:
 
-        xinterpreter() = default;
+        xinterpreter();
         virtual ~xinterpreter() = default;
 
         xinterpreter(const xinterpreter&) = delete;
@@ -44,6 +44,8 @@ namespace xeus
 
         xinterpreter(xinterpreter&&) = delete;
         xinterpreter& operator=(xinterpreter&&) = delete;
+
+        void configure();
 
         xjson execute_request(const std::string& code,
                               bool silent,
@@ -62,9 +64,9 @@ namespace xeus
         xjson is_complete_request(const std::string& code);
         xjson kernel_info_request();
 
-        // publish(msg_type, metadata, content) 
-        using publisher = std::function<void(const std::string&, xjson, xjson)>;
-        void register_publisher(const publisher& pub);
+        // publish(msg_type, metadata, content)
+        using publisher_type = std::function<void(const std::string&, xjson, xjson)>;
+        void register_publisher(const publisher_type& publisher);
 
         void publish_stream(const std::string& name, const std::string& text);
         void display_data(xjson data, xjson metadata, xjson transient);
@@ -76,13 +78,15 @@ namespace xeus
         void clear_output(bool wait);
 
         // send_stdin(msg_type, metadata, content)
-        using stdin_sender = std::function<void(const std::string&, xjson, xjson)>;
-        void register_stdin_sender(const stdin_sender& sender);
+        using stdin_sender_type = std::function<void(const std::string&, xjson, xjson)>;
+        void register_stdin_sender(const stdin_sender_type& sender);
 
         void input_request(const std::string& prompt, bool pwd);
         void input_reply(const std::string& value);
 
     private:
+
+        virtual void configure_impl() = 0;
 
         virtual xjson execute_request_impl(int execution_counter,
                                            const std::string& code,
@@ -108,8 +112,8 @@ namespace xeus
 
         xjson build_display_content(xjson data, xjson metadata, xjson transient);
 
-        publisher m_publisher;
-        stdin_sender m_stdin;
+        publisher_type m_publisher;
+        stdin_sender_type m_stdin;
         int m_execution_count;
     };
 

--- a/src/xguid.cpp
+++ b/src/xguid.cpp
@@ -86,8 +86,21 @@ namespace xeus
 #endif
     }
 
-    std::string xguid::to_string() const noexcept
+    xguid::xguid(const char* hex)
     {
-        return hex_string(m_buffer);
+        for (std::size_t i = 0; i < GUID_SIZE; ++i)
+        {
+            m_buffer[i] = (unsigned char)strtol(hex + 2 * i, NULL, 16);
+        }
+    }
+
+    std::string guid_to_hex(xguid uuid)
+    {
+        return hex_string(uuid.m_buffer);
+    }
+
+    xguid hex_to_guid(const char* hex)
+    {
+        return xguid(hex);
     }
 }

--- a/src/xinterpreter.cpp
+++ b/src/xinterpreter.cpp
@@ -11,6 +11,15 @@
 namespace xeus
 {
 
+    xinterpreter::xinterpreter() : m_execution_count(0)
+    {
+    }
+
+    void xinterpreter::configure()
+    {
+        configure_impl();
+    }
+
     xjson xinterpreter::execute_request(const std::string& code,
                                         bool silent,
                                         bool store_history,
@@ -58,9 +67,9 @@ namespace xeus
         return kernel_info_request_impl();
     }
 
-    void xinterpreter::register_publisher(const publisher& pub)
+    void xinterpreter::register_publisher(const publisher_type& publisher)
     {
-        m_publisher = pub;
+        m_publisher = publisher;
     }
 
     void xinterpreter::publish_stream(const std::string& name, const std::string& text)
@@ -121,7 +130,7 @@ namespace xeus
         m_publisher("clear_output", xjson(), std::move(content));
     }
 
-    void xinterpreter::register_stdin_sender(const stdin_sender& sender)
+    void xinterpreter::register_stdin_sender(const stdin_sender_type& sender)
     {
         m_stdin = sender;
     }

--- a/src/xkernel.cpp
+++ b/src/xkernel.cpp
@@ -67,11 +67,8 @@ namespace xeus
 
     void xkernel::start()
     {
-        zmq::context_t context;
-        server_ptr server = m_builder(context, m_config);
-
-        std::string kernel_id = xguid().to_string();
-        std::string session_id = xguid().to_string();
+        std::string kernel_id = guid_to_hex(xguid());
+        std::string session_id = guid_to_hex(xguid());
 
         using authentication_ptr = xkernel_core::authentication_ptr;
         authentication_ptr auth = make_xauthentication(m_config.m_signature_scheme, m_config.m_key);
@@ -79,9 +76,13 @@ namespace xeus
         zmq::multipart_t start_msg;
         build_start_msg(auth, kernel_id, m_user_name, session_id, start_msg);
 
+        zmq::context_t context;
+        server_ptr server = m_builder(context, m_config);
+
         xkernel_core core(kernel_id, m_user_name, session_id,
                           std::move(auth), server.get(), p_interpreter.get());
 
+        p_interpreter->configure(); 
         server->start(start_msg);
     }
 

--- a/src/xkernel_core.cpp
+++ b/src/xkernel_core.cpp
@@ -6,8 +6,13 @@
 * The full license is in the file LICENSE, distributed with this software. *
 ****************************************************************************/
 
-#include "xkernel_core.hpp"
+#include <exception>
+#include <functional>
 #include <iostream>
+#include <string>
+#include <tuple>
+
+#include "xkernel_core.hpp"
 
 using namespace std::placeholders;
 
@@ -75,8 +80,6 @@ namespace xeus
 
         const xjson& header = msg.header();
         std::string msg_type = header.get_string("/msg_type", "");
-
-
     }
 
     void xkernel_core::publish_message(const std::string& msg_type,
@@ -137,9 +140,9 @@ namespace xeus
             {
                 (this->*handler)(msg, c);
             }
-            catch (std::exception&)
+            catch (std::exception& e)
             {
-                std::cout << "ERROR: received bad message" << std::endl;
+                std::cout << "ERROR: received bad message: " << e.what() << std::endl;
             }
         }
 
@@ -182,9 +185,10 @@ namespace xeus
                 p_server->abort_queue(std::bind(&xkernel_core::abort_request, this, _1), 50);
             }
         }
-        catch (std::exception&)
+        catch (std::exception& e)
         {
-            // TODO : log received bad message
+            std::cout << "ERROR: during execute_request" << std::endl;
+            std::cout << e.what() << std::endl;
         }
     }
 
@@ -323,9 +327,9 @@ namespace xeus
         {
             msg.deserialize(wire_msg, *p_auth);
         }
-        catch (std::exception&)
+        catch (std::exception& e)
         {
-            // TODO : log error
+            std::cout << "ERROR: during execute_request: " << e.what() << std::endl;
             return;
         }
         const xjson& header = msg.header();
@@ -370,5 +374,4 @@ namespace xeus
     {
         return m_parent_header.copy();
     }
-
 }

--- a/src/xkernel_core.hpp
+++ b/src/xkernel_core.hpp
@@ -10,6 +10,7 @@
 #define XKERNEL_CORE_HPP
 
 #include <map>
+
 #include "xserver.hpp"
 #include "xinterpreter.hpp"
 #include "xauthentication.hpp"
@@ -20,7 +21,6 @@ namespace xeus
 
     class xkernel_core
     {
-
     public:
 
         using authentication_ptr = std::unique_ptr<xauthentication>;
@@ -67,6 +67,7 @@ namespace xeus
         void history_request(const xmessage& request, channel c);
         void is_complete_request(const xmessage& request, channel c);
         void comm_info_request(const xmessage& request, channel c);
+
         void kernel_info_request(const xmessage& request, channel c);
         void shutdown_request(const xmessage& request, channel c);
 
@@ -103,7 +104,6 @@ namespace xeus
         authentication_ptr p_auth;
 
         std::map<std::string, handler_type> m_handler;
-
         server_ptr p_server;
         interpreter_ptr p_interpreter;
 

--- a/src/xmessage.cpp
+++ b/src/xmessage.cpp
@@ -6,6 +6,8 @@
 * The full license is in the file LICENSE, distributed with this software. *
 ****************************************************************************/
 
+#include <cstddef>
+
 #include "xmessage.hpp"
 #include "xguid.hpp"
 
@@ -40,7 +42,7 @@ namespace xeus
 
     bool xmessage_base::is_delimiter(zmq::message_t& frame) const
     {
-        size_t frame_size = frame.size();
+        std::size_t frame_size = frame.size();
         if (frame_size != xmessage_base::DELIMITER.size())
             return false;
 
@@ -202,7 +204,7 @@ namespace xeus
                       const std::string& session_id)
     {
         xjson header;
-        header.set_value("/msg_id", xguid().to_string());
+        header.set_value("/msg_id", guid_to_hex(xguid()));
         header.set_value("/username", user_name);
         header.set_value("/session", session_id);
         header.set_value("/date", iso8601_now());

--- a/src/xpublisher.hpp
+++ b/src/xpublisher.hpp
@@ -16,7 +16,6 @@ namespace xeus
 
     class xpublisher
     {
-
     public:
 
         xpublisher(zmq::context_t& context,

--- a/src/xstring_utils.hpp
+++ b/src/xstring_utils.hpp
@@ -10,6 +10,7 @@
 #define XSTRING_UTILS_HPP
 
 #include <array>
+#include <cstddef>
 #include <string>
 #include <sstream>
 #include <iomanip>
@@ -17,12 +18,12 @@
 namespace xeus
 {
 
-    template <class T, size_t N>
+    template <class T, std::size_t N>
     inline std::string hex_string(const std::array<T, N>& buffer)
     {
         std::ostringstream oss;
         oss << std::hex;
-        for (size_t i = 0; i < N; ++i)
+        for (std::size_t i = 0; i < N; ++i)
         {
             oss << std::setw(2) << std::setfill('0') << static_cast<int>(buffer[i]);
         }


### PR DESCRIPTION
- `xguid` cleanup:

  - Now xguid opjects can only be default constructed or passed around with value semantics.
  - An xguid may be obtained with the `hex_to_xguid` function that takes a `const char*`.
  - The `to_string` method was removed. Now the `xguid_to_hex` free function returns the hexadecimal string.

- The `xinterpreter` has a `configure` pure virtual function.
   - `configure` is called by the kernel *before* starting the main loop, but *after* setting everything else was set up, that is when the publishers, and comm managers have been set up.

- This adds the ostream `operator<<` to xjson for debugging purpose.