### PR TITLE
WIP - The comm target takes ownership of the new comm

### DIFF
--- a/example/echo_kernel/echo_interpreter.cpp
+++ b/example/echo_kernel/echo_interpreter.cpp
@@ -16,11 +16,11 @@ namespace echo_kernel
 
     void echo_interpreter::configure_impl()
     {
-        auto handle_comm_opened = [](const xeus::xcomm& comm, const xeus::xmessage&) {
+        auto handle_comm_opened = [](xeus::xcomm&& comm, const xeus::xmessage&) {
             std::cout << "Comm opened for target: " << comm.target().name() << std::endl;
         };
         comm_manager().register_comm_target("echo_target", handle_comm_opened);
-        using function_type = std::function<void(const xeus::xcomm&, const xeus::xmessage&)>;
+        using function_type = std::function<void(xeus::xcomm&&, const xeus::xmessage&)>;
     }
 
     xjson echo_interpreter::execute_request_impl(int execution_counter,

--- a/include/xeus/xcomm.hpp
+++ b/include/xeus/xcomm.hpp
@@ -35,7 +35,7 @@ namespace xeus
     {
     public:
 
-        using function_type = std::function<void(const xcomm&, const xmessage&)>;
+        using function_type = std::function<void(xcomm&&, const xmessage&)>;
 
         xtarget();
         xtarget(const std::string& name, const function_type& callback, xcomm_manager* manager);
@@ -44,7 +44,7 @@ namespace xeus
         const std::string& name() const & noexcept;
         std::string name() const && noexcept;
 
-        void operator()(const xcomm& comm, const xmessage& request) const;
+        void operator()(xcomm&& comm, const xmessage& request) const;
 
         void publish_message(const std::string&, xjson, xjson) const;
 
@@ -197,9 +197,9 @@ namespace xeus
         return m_name;
     }
 
-    inline void xtarget::operator()(const xcomm& comm, const xmessage& message) const
+    inline void xtarget::operator()(xcomm&& comm, const xmessage& message) const
     {
-        return m_callback(comm, message);
+        return m_callback(std::move(comm), message);
     }
 
     inline void xtarget::register_comm(xguid id, xcomm* comm) const

--- a/src/xcomm.cpp
+++ b/src/xcomm.cpp
@@ -59,8 +59,7 @@ namespace xeus
             xtarget& target = position->second;
             xguid id = content["comm_id"];
             xcomm comm = xcomm(&target, id);
-            target(comm, request);
-            comm.open(get_metadata(), content["data"]);
+            target(std::move(comm), request);
         }
     }
 

--- a/src/xkernel_core.cpp
+++ b/src/xkernel_core.cpp
@@ -266,7 +266,7 @@ namespace xeus
     {
         const xjson& content = request.content();
         std::string target_name = content.is_null() ? "" : content.value("target_name", "");
-        xjson comms;
+        auto comms = xjson::object();
         for (auto it = m_comm_manager.comms().cbegin(); it != m_comm_manager.comms().cend(); ++it)
         {
             const std::string& name = it->second->target().name();


### PR DESCRIPTION

- Do not call `comm_open` for comms created from the front-end. (Note, although, the kernel should probably broadcast the comm-open to the other clients? cc @jasongrout, it does not seem to be done in ipykernel).

- The comms created in the handlers to `comm_open` message are local variables. It should be passed as an `rvalue` to the handler function so that they can take ownership of it, e.g. in a widget.

This is a backward incompatible change, since it changes the signature of the comm-open handlers.