### PR TITLE
Include cppzmq's fallback for finding zeromq with pkg-config

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,7 +13,12 @@ project(xeus)
 # ============
 
 find_package(xtl REQUIRED)
-find_package(ZeroMQ REQUIRED)
+find_package(ZeroMQ QUIET)
+if(NOT ZeroMQ_FOUND)
+    # try again with pkg-config (normal install of zeromq)
+    list (APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_LIST_DIR}/libzmq-pkg-config)
+    find_package(ZeroMQ REQUIRED)
+endif()
 find_package(cppzmq REQUIRED)
 find_package(cryptopp REQUIRED)
 
@@ -215,3 +220,5 @@ install(FILES ${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}Config.cmake
               ${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}ConfigVersion.cmake
               DESTINATION ${XEUS_CMAKECONFIG_INSTALL_DIR})
 
+install(FILES ${CMAKE_CURRENT_LIST_DIR}/libzmq-pkg-config/FindZeroMQ.cmake
+              DESTINATION ${XEUS_CMAKECONFIG_INSTALL_DIR}/libzmq-pkg-config)

--- a/libzmq-pkg-config/FindZeroMQ.cmake
+++ b/libzmq-pkg-config/FindZeroMQ.cmake
@@ -1,0 +1,29 @@
+# from cppzmq
+# fallback for normal libzmq installs, which don't have cmake files
+
+find_package(PkgConfig REQUIRED)
+pkg_check_modules(PC_LIBZMQ QUIET libzmq)
+
+set(ZeroMQ_VERSION ${PC_LIBZMQ_VERSION})
+find_library(ZeroMQ_LIBRARY NAMES libzmq.so libzmq.dylib libzmq.dll
+             PATHS ${PC_LIBZMQ_LIBDIR} ${PC_LIBZMQ_LIBRARY_DIRS})
+find_library(ZeroMQ_STATIC_LIBRARY NAMES libzmq.a libzmq.dll.a
+             PATHS ${PC_LIBZMQ_LIBDIR} ${PC_LIBZMQ_LIBRARY_DIRS})
+
+if(ZeroMQ_LIBRARY AND ZeroMQ_STATIC_LIBRARY)
+    set(ZeroMQ_FOUND ON)
+endif()
+
+if(TARGET libzmq)
+    # avoid error attempting to define targets twice
+    return()
+endif()
+
+
+add_library(libzmq SHARED IMPORTED)
+set_property(TARGET libzmq PROPERTY INTERFACE_INCLUDE_DIRECTORIES ${PC_LIBZMQ_INCLUDE_DIRS})
+set_property(TARGET libzmq PROPERTY IMPORTED_LOCATION ${ZeroMQ_LIBRARY})
+
+add_library(libzmq-static STATIC IMPORTED ${PC_LIBZMQ_INCLUDE_DIRS})
+set_property(TARGET libzmq-static PROPERTY INTERFACE_INCLUDE_DIRECTORIES ${PC_LIBZMQ_INCLUDE_DIRS})
+set_property(TARGET libzmq-static PROPERTY IMPORTED_LOCATION ${ZeroMQ_STATIC_LIBRARY})


### PR DESCRIPTION
This allows xeus to build against normal installs of libzmq, as cppzmq does.

by adding the fallback as FindZeroMQ.cmake, subsequent packages will succeed when they call `find_package(ZeroMQ)`. It's in its own directory, so the fallback is only used if the initial load fails.

After https://github.com/zeromq/cppzmq/pull/174 this would be unnecessary,
as only requiring cppzmq would find ZeroMQ in a way that any package could share.