### PR TITLE
cmake: Require version >= 3.8 to ensure try_compile consider CMAKE_(C|CXX)_STANDARD

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,7 +6,7 @@
 # The full license is in the file LICENSE, distributed with this software. #
 ############################################################################
 
-cmake_minimum_required(VERSION 3.1)
+cmake_minimum_required(VERSION 3.8)
 project(xeus)
 
 set(XEUS_INCLUDE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/include)


### PR DESCRIPTION


This will ensure the configure check testing if CryptoPP::byte is
available works as expected.

See https://cmake.org/cmake/help/v3.11/policy/CMP0067.html