### PR TITLE
Use pkg-config to find zeromq

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -87,7 +87,8 @@ install:
     - conda config --set always_yes yes --set changeps1 no
     - conda update -q conda
     - conda info -a
-    - conda install toolchain cmake zeromq cppzmq cryptopp xtl -c conda-forge
+    - conda install toolchain cmake pkg-config -c conda-forge
+    - conda install zeromq cppzmq cryptopp xtl -c conda-forge
     - conda install nlohmann_json -c QuantStack
     # Build
     - mkdir build

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -46,11 +46,21 @@ message(STATUS "xeus binary version: v${XEUS_BINARY_VERSION}")
 # Dependencies
 # ============
 
+# Dependencies that provide cmake project config
+
 find_package(nlohmann_json 3.1.1 REQUIRED)
 find_package(xtl 0.4 REQUIRED)
-find_package(ZeroMQ 4.2.3 REQUIRED)
 find_package(cppzmq 4.2.3 REQUIRED)
 find_package(cryptopp REQUIRED)
+
+# Dependencies built with autotools
+
+if (WIN32)
+    find_package(zeromq 4.2.3 REQUIRED)
+else()
+    find_package(PkgConfig)
+    pkg_check_modules(ZeroMQ libzmq>=4.2.3 REQUIRED)
+endif()
 
 # Source files
 # ============


### PR DESCRIPTION
Even though zeromq's repository includes cmake files, the default build system for `zeromq` is autotools, and therefore, the cmake artefacts are not installed by default. (We happen to manually generate then in the case of conda but that is not the case for other package managers).

Cmake has the possibility of finding packages that have a `.pc` file using the `PkgConfig` module.

Now using `PkgConfig` so that @yurivict can continue on his work to package xeus and xeus-cling for freebsd.

cf #74 