### PR TITLE
Add parent_header getter for output widget

### DIFF
--- a/include/xeus/xinterpreter.hpp
+++ b/include/xeus/xinterpreter.hpp
@@ -78,9 +78,12 @@ namespace xeus
         void input_reply(const std::string& value);
 
         void register_comm_manager(xcomm_manager* manager);
-
         xcomm_manager& comm_manager() noexcept;
         const xcomm_manager& comm_manager() const noexcept;
+
+        using parent_header_type = std::function<const xjson&()>;
+        void register_parent_header(const parent_header_type&);
+        const xjson& parent_header() const noexcept;
 
     private:
 
@@ -112,6 +115,7 @@ namespace xeus
         stdin_sender_type m_stdin;
         int m_execution_count;
         xcomm_manager* p_comm_manager;
+        parent_header_type m_parent_header;
         input_reply_handler_type m_input_reply_handler;
     };
 

--- a/src/xinterpreter.cpp
+++ b/src/xinterpreter.cpp
@@ -172,6 +172,24 @@ namespace xeus
         p_comm_manager = manager;
     }
 
+    void xinterpreter::register_parent_header(const parent_header_type& parent_header)
+    {
+        m_parent_header = parent_header;
+    }
+
+    const xjson& xinterpreter::parent_header() const noexcept
+    {
+        static const auto dummy = xjson::object();
+        if (m_parent_header)
+        {
+            return m_parent_header();
+        }
+        else
+        {
+            return dummy;
+        }
+    }
+
     void xinterpreter::input_request(const std::string& prompt, bool pwd)
     {
         if (m_stdin)

--- a/src/xkernel_core.cpp
+++ b/src/xkernel_core.cpp
@@ -59,6 +59,7 @@ namespace xeus
         p_interpreter->register_publisher(std::bind(&xkernel_core::publish_message, this, _1, _2, _3, _4));
         p_interpreter->register_stdin_sender(std::bind(&xkernel_core::send_stdin, this, _1, _2, _3));
         p_interpreter->register_comm_manager(&m_comm_manager);
+        p_interpreter->register_parent_header(std::bind(&xkernel_core::parent_header, this));
     }
 
     xkernel_core::~xkernel_core()
@@ -156,6 +157,11 @@ namespace xeus
     xcomm_manager xkernel_core::comm_manager() const && noexcept
     {
         return m_comm_manager;
+    }
+
+    const xjson& xkernel_core::parent_header() const noexcept
+    {
+        return m_parent_header;
     }
 
     void xkernel_core::dispatch(zmq::multipart_t& wire_msg, channel c)
@@ -420,7 +426,7 @@ namespace xeus
                                   const xjson& parent_header)
     {
         m_parent_id = parent_id;
-        m_parent_header = xjson(parent_header);
+        m_parent_header = parent_header;
     }
 
     const xkernel_core::guid_list& xkernel_core::get_parent_id() const

--- a/src/xkernel_core.hpp
+++ b/src/xkernel_core.hpp
@@ -56,6 +56,7 @@ namespace xeus
         xcomm_manager& comm_manager() & noexcept;
         const xcomm_manager& comm_manager() const & noexcept;
         xcomm_manager comm_manager() const && noexcept;
+        const xjson& parent_header() const noexcept;
 
     private:
 


### PR DESCRIPTION
Expose current parent header to xinterpreter for output widget implementation.

Fixes #131 