### PR TITLE
Migrate to OpenSSL

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -22,7 +22,7 @@ install:
   - conda config --set always_yes yes --set changeps1 no
   - conda update -q conda
   - conda info -a
-  - conda install cmake cppzmq=4.3.0 zeromq=4.2.5 xtl=0.6 nlohmann_json=3.4.0 cryptopp=7.0.0 -c conda-forge
+  - conda install cmake cppzmq=4.3.0 zeromq=4.2.5 xtl=0.6 nlohmann_json=3.4.0 OpenSSL=1 -c conda-forge
   - conda install pytest jupyter jupyter_kernel_test=0.3.0 -c conda-forge
   - mkdir build
   - cd build

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,7 @@ install:
     - conda update -q conda
     - conda info -a
     # Host dependencies
-    - conda install zeromq=4.2.5 cppzmq=4.3.0 xtl=0.6 cryptopp=7.0.0 nlohmann_json=3.4.0 -c conda-forge;
+    - conda install zeromq=4.2.5 cppzmq=4.3.0 xtl=0.6 OpenSSL=1 nlohmann_json=3.4.0 -c conda-forge;
     # Build dependencies
     - conda install cmake pkg-config -c conda-forge
     - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -74,23 +74,8 @@ else ()
      endif ()
 endif ()
 
-if (WIN32)
-    find_package(cryptopp REQUIRED)
-else ()
-    find_package(cryptopp QUIET)
-
-    if (NOT cryptopp_FOUND)
-        message(STATUS "CMake cryptopp package not found, trying again with pkg-config")
-        find_package(PkgConfig)
-        pkg_check_modules(cryptopp libcryptopp REQUIRED)
-        find_library(cryptopp_LIBRARY NAMES cryptopp-shared.dll libcryptopp.so libcryptopp.dylib)
-        add_library(cryptopp-shared SHARED IMPORTED)
-        set_target_properties(cryptopp-shared PROPERTIES IMPORTED_LOCATION ${cryptopp_LIBRARY})
-        find_library(cryptopp_STATIC_LIBRARY NAMES cryptopp-static.lib libcryptopp.a)
-        add_library(cryptopp-static STATIC IMPORTED)
-        set_target_properties(cryptopp-static PROPERTIES IMPORTED_LOCATION ${cryptopp_STATIC_LIBRARY})
-     endif ()
-endif ()
+set(OPENSSL_ROOT_DIR ${CMAKE_INSTALL_PREFIX})
+find_package(OpenSSL REQUIRED)
 
 # Source files
 # ============
@@ -142,7 +127,6 @@ include(CheckCXXCompilerFlag)
 
 string(TOUPPER "${CMAKE_BUILD_TYPE}" U_CMAKE_BUILD_TYPE)
 
-option(XEUS_USE_SHARED_CRYPTOPP "Used shared library for cryptopp" OFF)
 option(DISABLE_ARCH_NATIVE "disable -march=native flag" OFF)
 
 option(BUILD_SHARED_LIBS "Build xeus shared library." ON)
@@ -195,11 +179,7 @@ macro(xeus_create_target target_name linkage output_name)
         PUBLIC xtl
     )
 
-    if (XEUS_USE_SHARED_CRYPTOPP)
-        target_link_libraries(${target_name} PUBLIC cryptopp-shared)
-    else ()
-        target_link_libraries(${target_name} PUBLIC cryptopp-static)
-    endif ()
+    target_link_libraries(${target_name} PUBLIC OpenSSL::Crypto)
 
     if (NOT MSVC)
         if (APPLE)

--- a/README.md
+++ b/README.md
@@ -90,23 +90,23 @@ Kernel authors can then rebind to the native APIs of the interpreter that is bei
 ## Building from Source
 
 `xeus` depends on the following libraries: [`libzmq`](https://github.com/zeromq/libzmq),
-[`cppzmq`](https://github.com/zeromq/cppzmq), [`cryptopp`](https://github.com/weidai11/cryptopp),
+[`cppzmq`](https://github.com/zeromq/cppzmq), [`OpenSSL`](https://github.com/openssl/openssl),
 [`nlohmann_json`](https://github.com/nlohmann/json), and [`xtl`](https://github.com/QuantStack/xtl).
 
-|  xeus  | libzmq  | cppzmq  |    cryptopp    |   xtl          | nlohmann json |
-|--------|---------|---------|----------------|----------------|---------------|
-| master |  ^4.2.5 |  ^4.3.0 |         ^7.0.0 | >=0.5.0,<0.7.0 |      ^3.2.0   |
-| 0.18.1 |  ^4.2.5 |  ^4.3.0 |         ^7.0.0 | ^0.5.0         |      ^3.2.0   |
-| 0.18.0 |  ^4.2.5 |  ^4.3.0 |         ^7.0.0 | ^0.5.0         |      ^3.2.0   |
-| 0.17.0 |  ^4.2.5 |  ^4.3.0 |         ^7.0.0 | ^0.5.0         |      ^3.2.0   |
-| 0.16.0 |  ^4.2.5 |  ^4.3.0 | ^5.6.5, ^7.0.0 | ^0.4.0         |       3.2.0   |
-| 0.15.0 |  ^4.2.5 |  ^4.3.0 | ^5.6.5, ^7.0.0 | ^0.4.0         |       3.2.0   |
-| 0.14.1 |  ^4.2.5 |  ^4.3.0 | ^5.6.5, ^7.0.0 | ^0.4.0         |       3.1.2   |
-| 0.14.0 |  ^4.2.5 |  ^4.3.0 | ^5.6.5, ^7.0.0 | ^0.4.0         |       3.1.2   |
-| 0.13.0 |  ^4.2.3 |  ^4.2.5 | ^5.6.5, ^7.0.0 | ^0.4.0         |       3.1.1   |
-| 0.12.0 |  ^4.2.3 |  ^4.2.5 |          5.6.5 | ^0.4.0         |       3.1.1   |
-| 0.11.0 |  4.2.3  |   4.2.3 |          5.6.5 | ^0.4.0         |       3.1.1   |
-| 0.10.x |  4.2.3  |   4.2.3 |          5.6.5 | ^0.4.0         |               |
+|  xeus  | libzmq  | cppzmq  |    cryptopp    |   xtl          | nlohmann json | OpenSSL |
+|--------|---------|---------|----------------|----------------|---------------|---------|
+| master |  ^4.2.5 |  ^4.3.0 |  not required  | >=0.5.0,<0.7.0 |      ^3.2.0   |  ^1.0.1 |
+| 0.18.1 |  ^4.2.5 |  ^4.3.0 |         ^7.0.0 | ^0.5.0         |      ^3.2.0   |         |
+| 0.18.0 |  ^4.2.5 |  ^4.3.0 |         ^7.0.0 | ^0.5.0         |      ^3.2.0   |         |
+| 0.17.0 |  ^4.2.5 |  ^4.3.0 |         ^7.0.0 | ^0.5.0         |      ^3.2.0   |         |
+| 0.16.0 |  ^4.2.5 |  ^4.3.0 | ^5.6.5, ^7.0.0 | ^0.4.0         |       3.2.0   |         |
+| 0.15.0 |  ^4.2.5 |  ^4.3.0 | ^5.6.5, ^7.0.0 | ^0.4.0         |       3.2.0   |         |
+| 0.14.1 |  ^4.2.5 |  ^4.3.0 | ^5.6.5, ^7.0.0 | ^0.4.0         |       3.1.2   |         |
+| 0.14.0 |  ^4.2.5 |  ^4.3.0 | ^5.6.5, ^7.0.0 | ^0.4.0         |       3.1.2   |         |
+| 0.13.0 |  ^4.2.3 |  ^4.2.5 | ^5.6.5, ^7.0.0 | ^0.4.0         |       3.1.1   |         |
+| 0.12.0 |  ^4.2.3 |  ^4.2.5 |          5.6.5 | ^0.4.0         |       3.1.1   |         |
+| 0.11.0 |  4.2.3  |   4.2.3 |          5.6.5 | ^0.4.0         |       3.1.1   |         |
+| 0.10.x |  4.2.3  |   4.2.3 |          5.6.5 | ^0.4.0         |               |         |
 
 
 On Linux platforms, `xeus` also requires `libuuid`, which is available in all linux distributions (`uuid-dev` on Debian).
@@ -115,7 +115,7 @@ We have packaged all these dependencies for the conda package manager. The simpl
 conda is to run:
 
 ```bash
-conda install cmake pkg-config zeromq cppzmq xtl cryptopp -c conda-forge
+conda install cmake pkg-config zeromq cppzmq xtl OpenSSL -c conda-forge
 conda install nlohmann_json -c conda-forge/label/gcc7
 ```
 

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -21,7 +21,7 @@ From Source
 
 ``xeus`` depends on the following libraries:
 
- - libzmq_, cppzmq_, cryptopp_ and xtl_
+ - libzmq_, cppzmq_, OpenSSL_ and xtl_
 
 On linux platforms, ``xeus`` also requires libuuid, which is available in all linux distributions.
 
@@ -29,7 +29,7 @@ We have packaged all these dependencies for the conda package manager. The simpl
 
 .. code::
 
-    conda install cmake zeromq cppzmq cryptopp xtl -c conda-forge .
+    conda install cmake zeromq cppzmq OpenSSL xtl -c conda-forge .
 
 On Linux platform, you will also need:
 
@@ -71,18 +71,10 @@ cppzmq
     cmake -D CMAKE_BUILD_TYPE=Release .
     make install
 
-cryptopp
-~~~~~~~~~
+OpenSSL
+~~~~~~~
 
-`cryptopp` is can be built as a static or shared library. Building cryptopp as a shared library is not supported on Windows.
-
-.. code::
-
-    cmake -D BUILD_SHARED=OFF -D BUILD_TESTING=OFF -D CMAKE_BUILD_TYPE=Release .
-    make
-    make install
-
-If cryptopp is built as a shared library, the `XEUS_USE_SHARED_CRYPTOPP` cmake flag must be used for xeus.
+`OpenSSL` has been packaged for most platforms and package manager. It should generally not be required for the user to build it. 
 
 xtl
 ~~~
@@ -96,6 +88,6 @@ xtl
 
 .. _libzmq: https://github.com/zeromq/libzmq
 .. _cppzmq: https://github.com/zeromq/cppzmq
-.. _cryptopp: https://github.com/weidai11/cryptopp
+.. _OpenSSL: https://github.com/OpenSSL/OpenSSL
 .. _xtl: https://github.com/QuantStack/xtl
 

--- a/src/xstring_utils.hpp
+++ b/src/xstring_utils.hpp
@@ -17,12 +17,12 @@
 
 namespace xeus
 {
-    template <class T, std::size_t N>
-    inline std::string hex_string(const std::array<T, N>& buffer)
+    template <class B>
+    inline std::string hex_string(const B& buffer)
     {
         std::ostringstream oss;
         oss << std::hex;
-        for (std::size_t i = 0; i < N; ++i)
+        for (std::size_t i = 0; i < buffer.size(); ++i)
         {
             oss << std::setw(2) << std::setfill('0') << static_cast<int>(buffer[i]);
         }

--- a/xeusConfig.cmake.in
+++ b/xeusConfig.cmake.in
@@ -41,7 +41,7 @@ if(UNIX AND NOT APPLE)
     find_dependency(LibUUID)
 endif()
 
-find_dependency(cryptopp)
+find_dependency(OpenSSL)
 
 if(NOT TARGET xeus AND NOT TARGET xeus_static)
     include("${CMAKE_CURRENT_LIST_DIR}/@PROJECT_NAME@Targets.cmake")


### PR DESCRIPTION
Fixes #117.

This also enables the support for other signature schemes than sha256.