### PR TITLE
Add status to kernel info reply

### DIFF
--- a/src/xkernel_core.cpp
+++ b/src/xkernel_core.cpp
@@ -315,6 +315,7 @@ namespace xeus
     {
         xjson reply = p_interpreter->kernel_info_request();
         reply["protocol_version"] = get_protocol_version();
+        reply["status"] = "ok";
         send_reply("kernel_info_reply", xjson::object(), std::move(reply), c);
     }
 


### PR DESCRIPTION
Fixes https://github.com/computationalmodelling/nbval/issues/115

xeus was missing the "status" field in kernel info replies.