### PR TITLE
Debug

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -40,3 +40,4 @@ install:
 build_script:
   - .\test\test_xeus
   - py.test test\test_kernel.py
+  - py.test test\test_kernel_split.py

--- a/.travis.yml
+++ b/.travis.yml
@@ -56,3 +56,4 @@ script:
     - cd test
     - ./test_xeus
     - py.test test_kernel.py
+    - py.test test_kernel_split.py

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -95,6 +95,7 @@ set(XEUS_HEADERS
     ${XEUS_INCLUDE_DIR}/xeus/xmessage.hpp
     ${XEUS_INCLUDE_DIR}/xeus/xserver.hpp
     ${XEUS_INCLUDE_DIR}/xeus/xserver_zmq.hpp
+    ${XEUS_INCLUDE_DIR}/xeus/xserver_zmq_split.hpp
 )
 
 set(XEUS_SOURCES
@@ -120,6 +121,9 @@ set(XEUS_SOURCES
     ${XEUS_SOURCE_DIR}/xpublisher.hpp
     ${XEUS_SOURCE_DIR}/xserver.cpp
     ${XEUS_SOURCE_DIR}/xserver_zmq.cpp
+    ${XEUS_SOURCE_DIR}/xserver_zmq_split.cpp
+    ${XEUS_SOURCE_DIR}/xshell.hpp
+    ${XEUS_SOURCE_DIR}/xshell.cpp
     ${XEUS_SOURCE_DIR}/xstring_utils.hpp
 )
 

--- a/include/xeus/xserver.hpp
+++ b/include/xeus/xserver.hpp
@@ -19,6 +19,12 @@
 
 namespace xeus
 {
+    enum class channel
+    {
+        SHELL,
+        CONTROL
+    };
+
     class XEUS_API xserver
     {
     public:
@@ -36,7 +42,7 @@ namespace xeus
         void send_shell(zmq::multipart_t& message);
         void send_control(zmq::multipart_t& message);
         void send_stdin(zmq::multipart_t& message);
-        void publish(zmq::multipart_t& message);
+        void publish(zmq::multipart_t& message, channel c = channel::SHELL);
 
         void start(zmq::multipart_t& message);
         void abort_queue(const listener& l, long polling_interval);
@@ -60,7 +66,7 @@ namespace xeus
         virtual void send_shell_impl(zmq::multipart_t& message) = 0;
         virtual void send_control_impl(zmq::multipart_t& message) = 0;
         virtual void send_stdin_impl(zmq::multipart_t& message) = 0;
-        virtual void publish_impl(zmq::multipart_t& message) = 0;
+        virtual void publish_impl(zmq::multipart_t& message, channel c) = 0;
 
         virtual void start_impl(zmq::multipart_t& message) = 0;
         virtual void abort_queue_impl(const listener& l, long polling_interval) = 0;

--- a/include/xeus/xserver_zmq.hpp
+++ b/include/xeus/xserver_zmq.hpp
@@ -34,7 +34,7 @@ namespace xeus
         void send_shell_impl(zmq::multipart_t& message) override;
         void send_control_impl(zmq::multipart_t& message) override;
         void send_stdin_impl(zmq::multipart_t& message) override;
-        void publish_impl(zmq::multipart_t& message) override;
+        void publish_impl(zmq::multipart_t& message, channel c) override;
 
         void start_impl(zmq::multipart_t& message) override;
         void abort_queue_impl(const listener& l, long polling_interval) override;

--- a/include/xeus/xserver_zmq_split.hpp
+++ b/include/xeus/xserver_zmq_split.hpp
@@ -1,0 +1,73 @@
+/***************************************************************************
+* Copyright (c) 2018, Johan Mabille, Sylvain Corlay and Martin Renou       *
+*                                                                          *
+* Distributed under the terms of the BSD 3-Clause License.                 *
+*                                                                          *
+* The full license is in the file LICENSE, distributed with this software. *
+****************************************************************************/
+
+#ifndef XEUS_SERVER_ZMQ_SPLIT_HPP
+#define XEUS_SERVER_ZMQ_SPLIT_HPP
+
+#include "xeus/xeus.hpp"
+#include "xeus/xserver.hpp"
+#include "xeus/xkernel_configuration.hpp"
+
+namespace xeus
+{
+    class xshell;
+    class xpublisher;
+    class xheartbeat;
+
+    class XEUS_API xserver_zmq_split : public xserver
+    {
+    public:
+
+        using shell_ptr = std::unique_ptr<xshell>;
+        using publisher_ptr = std::unique_ptr<xpublisher>;
+        using heartbeat_ptr = std::unique_ptr<xheartbeat>;
+
+        xserver_zmq_split(zmq::context_t& context, const xconfiguration& config);
+
+        virtual ~xserver_zmq_split();
+
+        // The xshell object needs to call these methods
+        using xserver::notify_shell_listener;
+        using xserver::notify_stdin_listener;
+
+    protected:
+
+        void send_shell_impl(zmq::multipart_t& message) override;
+        void send_control_impl(zmq::multipart_t& message) override;
+        void send_stdin_impl(zmq::multipart_t& message) override;
+        void publish_impl(zmq::multipart_t& message, channel c) override;
+
+        void start_impl(zmq::multipart_t& message) override;
+        void abort_queue_impl(const listener& l, long polling_interval) override;
+        void stop_impl() override;
+        void update_config_impl(xconfiguration& config) const override;
+
+        void start_shell_thread();
+        void start_publisher_thread();
+        void start_heartbeat_thread();
+        void stop_channels();
+
+        // External socket for controller channel
+        zmq::socket_t m_controller;
+        // Internal socket for pusblishing
+        zmq::socket_t m_publisher_pub;
+        // Internal sockets for controlling other threads
+        zmq::socket_t m_shell_controller;
+        zmq::socket_t m_publisher_controller;
+        zmq::socket_t m_heartbeat_controller;
+
+        shell_ptr p_shell;
+        publisher_ptr p_publisher;
+        heartbeat_ptr p_heartbeat;
+
+        bool m_request_stop;
+    };
+}
+
+#endif
+

--- a/src/xheartbeat.cpp
+++ b/src/xheartbeat.cpp
@@ -23,7 +23,7 @@ namespace xeus
         , m_controller(context, zmq::socket_type::rep)
     {
         init_socket(m_heartbeat, transport, ip, port);
-        init_socket(m_controller, get_heartbeat_controller_end_point());
+        init_socket(m_controller, get_controller_end_point("heartbeat"));
     }
 
     xheartbeat::~xheartbeat()

--- a/src/xkernel_core.hpp
+++ b/src/xkernel_core.hpp
@@ -60,13 +60,7 @@ namespace xeus
 
     private:
 
-        enum class channel
-        {
-            SHELL,
-            CONTROL
-        };
-
-        using handler_type = void (xkernel_core::*)(const xmessage&, xkernel_core::channel);
+        using handler_type = void (xkernel_core::*)(const xmessage&, channel);
         using guid_list = xmessage::guid_list;
 
         void dispatch(zmq::multipart_t& wire_msg, channel c);

--- a/src/xmiddleware.cpp
+++ b/src/xmiddleware.cpp
@@ -14,14 +14,9 @@
 
 namespace xeus
 {
-    std::string get_publisher_controller_end_point()
+    std::string get_controller_end_point(const std::string& channel)
     {
-        return "inproc://publisher_controller";
-    }
-
-    std::string get_heartbeat_controller_end_point()
-    {
-        return "inproc://heartbeat_controller";
+        return "inproc://" + channel + "_controller";
     }
 
     std::string get_publisher_end_point()

--- a/src/xmiddleware.hpp
+++ b/src/xmiddleware.hpp
@@ -13,8 +13,7 @@
 
 namespace xeus
 {
-    std::string get_publisher_controller_end_point();
-    std::string get_heartbeat_controller_end_point();
+    std::string get_controller_end_point(const std::string& channel);
     std::string get_publisher_end_point();
 
     std::string get_end_point(const std::string& transport,

--- a/src/xpublisher.cpp
+++ b/src/xpublisher.cpp
@@ -7,6 +7,7 @@
 ****************************************************************************/
 
 #include <string>
+#include <iostream>
 
 #include "xpublisher.hpp"
 #include "zmq_addon.hpp"
@@ -23,10 +24,10 @@ namespace xeus
         , m_controller(context, zmq::socket_type::rep)
     {
         init_socket(m_publisher, transport, ip, port);
-        m_listener.connect(get_publisher_end_point());
         m_listener.setsockopt(ZMQ_SUBSCRIBE, "", 0);
+        m_listener.bind(get_publisher_end_point());
         m_controller.setsockopt(ZMQ_LINGER, get_socket_linger());
-        m_controller.bind(get_publisher_controller_end_point());
+        m_controller.bind(get_controller_end_point("publisher"));
     }
 
     xpublisher::~xpublisher()

--- a/src/xpublisher.hpp
+++ b/src/xpublisher.hpp
@@ -11,8 +11,6 @@
 
 #include <string>
 
-#include <string>
-
 #include "zmq.hpp"
 
 namespace xeus

--- a/src/xserver.cpp
+++ b/src/xserver.cpp
@@ -10,6 +10,7 @@
 
 #include "xeus/xserver.hpp"
 #include "xeus/xserver_zmq.hpp"
+#include "xeus/xserver_zmq_split.hpp"
 
 namespace xeus
 {
@@ -28,9 +29,9 @@ namespace xeus
         send_stdin_impl(message);
     }
 
-    void xserver::publish(zmq::multipart_t& message)
+    void xserver::publish(zmq::multipart_t& message, channel c)
     {
-        publish_impl(message);
+        publish_impl(message, c);
     }
 
     void xserver::start(zmq::multipart_t& message)

--- a/src/xserver_zmq.cpp
+++ b/src/xserver_zmq.cpp
@@ -33,12 +33,13 @@ namespace xeus
         init_socket(m_shell, config.m_transport, config.m_ip, config.m_shell_port);
         init_socket(m_controller, config.m_transport, config.m_ip, config.m_control_port);
         init_socket(m_stdin, config.m_transport, config.m_ip, config.m_stdin_port);
-        init_socket(m_publisher_pub, get_publisher_end_point());
+        m_publisher_pub.setsockopt(ZMQ_LINGER, get_socket_linger());
+        m_publisher_pub.connect(get_publisher_end_point());
 
         m_publisher_controller.setsockopt(ZMQ_LINGER, get_socket_linger());
-        m_publisher_controller.connect(get_publisher_controller_end_point());
+        m_publisher_controller.connect(get_controller_end_point("publisher"));
         m_heartbeat_controller.setsockopt(ZMQ_LINGER, get_socket_linger());
-        m_heartbeat_controller.connect(get_heartbeat_controller_end_point());
+        m_heartbeat_controller.connect(get_controller_end_point("heartbeat"));
     }
 
     xserver_zmq::~xserver_zmq()
@@ -63,7 +64,7 @@ namespace xeus
         xserver::notify_stdin_listener(wire_msg);
     }
 
-    void xserver_zmq::publish_impl(zmq::multipart_t& message)
+    void xserver_zmq::publish_impl(zmq::multipart_t& message, channel)
     {
         message.send(m_publisher_pub);
     }

--- a/src/xserver_zmq_split.cpp
+++ b/src/xserver_zmq_split.cpp
@@ -1,0 +1,157 @@
+/***************************************************************************
+* Copyright (c) 2018, Johan Mabille, Sylvain Corlay and Martin Renou       *
+*                                                                          *
+* Distributed under the terms of the BSD 3-Clause License.                 *
+*                                                                          *
+* The full license is in the file LICENSE, distributed with this software. *
+****************************************************************************/
+
+#include <thread>
+#include <chrono>
+#include <iostream>
+
+#include "xeus/xserver_zmq_split.hpp"
+#include "xeus/xguid.hpp"
+#include "zmq_addon.hpp"
+#include "xmiddleware.hpp"
+#include "xpublisher.hpp"
+#include "xheartbeat.hpp"
+#include "xshell.hpp"
+
+namespace xeus
+{
+    xserver_zmq_split::xserver_zmq_split(zmq::context_t& context, const xconfiguration& config)
+        : m_controller(context, zmq::socket_type::router)
+        , m_publisher_pub(context, zmq::socket_type::pub)
+        , m_shell_controller(context, zmq::socket_type::req)
+        , m_publisher_controller(context, zmq::socket_type::req)
+        , m_heartbeat_controller(context, zmq::socket_type::req)
+        , p_shell(new xshell(context, config.m_transport, config.m_ip ,config.m_shell_port, config.m_stdin_port, this))
+        , p_publisher(new xpublisher(context, config.m_transport, config.m_ip, config.m_iopub_port))
+        , p_heartbeat(new xheartbeat(context, config.m_transport, config.m_ip, config.m_hb_port))
+        , m_request_stop(false)
+    {
+        init_socket(m_controller, config.m_transport, config.m_ip, config.m_control_port);
+        m_publisher_pub.setsockopt(ZMQ_LINGER, get_socket_linger());
+        m_publisher_pub.connect(get_publisher_end_point());
+
+        m_shell_controller.setsockopt(ZMQ_LINGER, get_socket_linger());
+        m_shell_controller.connect(get_controller_end_point("shell"));
+        m_publisher_controller.setsockopt(ZMQ_LINGER, get_socket_linger());
+        m_publisher_controller.connect(get_controller_end_point("publisher"));
+        m_heartbeat_controller.setsockopt(ZMQ_LINGER, get_socket_linger());
+        m_heartbeat_controller.connect(get_controller_end_point("heartbeat"));
+    }
+
+    xserver_zmq_split::~xserver_zmq_split()
+    {
+    }
+
+    void xserver_zmq_split::send_shell_impl(zmq::multipart_t& message)
+    {
+        // Shell thread only
+        p_shell->send_shell(message);
+    }
+
+    void xserver_zmq_split::send_control_impl(zmq::multipart_t& message)
+    {
+        // Control (or main) thread only
+        message.send(m_controller);
+    }
+
+    void xserver_zmq_split::send_stdin_impl(zmq::multipart_t& message)
+    {
+        // Shell thread only
+        p_shell->send_stdin(message);
+    }
+    
+    void xserver_zmq_split::publish_impl(zmq::multipart_t& message, channel c)
+    {
+        if(c == channel::SHELL)
+        {
+            p_shell->publish(message);
+        }
+        else
+        {
+            message.send(m_publisher_pub);
+        }
+    }
+    
+    void xserver_zmq_split::start_impl(zmq::multipart_t& message)
+    {
+        start_publisher_thread();
+        start_heartbeat_thread();
+        start_shell_thread();
+
+        m_request_stop = false;
+
+        publish(message, channel::CONTROL);
+
+        while (!m_request_stop)
+        {
+            zmq::multipart_t wire_msg;
+            wire_msg.recv(m_controller);
+            xserver::notify_control_listener(wire_msg);
+        }
+
+        stop_channels();
+
+        std::exit(0);
+    }
+
+    void xserver_zmq_split::abort_queue_impl(const listener& l, long polling_interval)
+    {
+        p_shell->abort_queue(l, polling_interval);
+    }
+
+    void xserver_zmq_split::stop_impl()
+    {
+        m_request_stop = true;
+    }
+
+    void xserver_zmq_split::update_config_impl(xconfiguration& config) const
+    {
+        config.m_control_port = get_socket_port(m_controller);
+        config.m_shell_port = p_shell->get_shell_port();
+        config.m_stdin_port = p_shell->get_stdin_port();
+        config.m_iopub_port = p_publisher->get_port();
+        config.m_hb_port = p_heartbeat->get_port();
+    }
+
+    void xserver_zmq_split::start_shell_thread()
+    {
+        std::thread shell_thread(&xshell::run, p_shell.get());
+        shell_thread.detach();
+    }
+
+    void xserver_zmq_split::start_publisher_thread()
+    {
+        std::thread iopub_thread(&xpublisher::run, p_publisher.get());
+        iopub_thread.detach();
+    }
+
+    void xserver_zmq_split::start_heartbeat_thread()
+    {
+        std::thread hb_thread(&xheartbeat::run, p_heartbeat.get());
+        hb_thread.detach();
+    }
+
+    void xserver_zmq_split::stop_channels()
+    {
+        zmq::message_t stop_msg("stop", 4);
+        zmq::message_t response;
+
+        // Wait for shell answer
+        m_shell_controller.send(stop_msg);
+        m_shell_controller.recv(&response);
+
+        // Wait for publisher answer
+        m_publisher_controller.send(stop_msg);
+        m_publisher_controller.recv(&response);
+
+        // Wait for heartbeat answer
+        m_heartbeat_controller.send(stop_msg);
+        m_heartbeat_controller.recv(&response);
+    }
+}
+

--- a/src/xshell.cpp
+++ b/src/xshell.cpp
@@ -1,0 +1,117 @@
+/***************************************************************************
+* Copyright (c) 2018, Johan Mabille, Sylvain Corlay and Martin Renou       *
+*                                                                          *
+* Distributed under the terms of the BSD 3-Clause License.                 *
+*                                                                          *
+* The full license is in the file LICENSE, distributed with this software. *
+****************************************************************************/
+
+#include <thread>
+#include <chrono>
+#include <iostream>
+
+#include "xshell.hpp"
+#include "xmiddleware.hpp"
+#include "xeus/xserver_zmq_split.hpp"
+
+namespace xeus
+{
+    xshell::xshell(zmq::context_t& context,
+                   const std::string& transport,
+                   const std::string& ip,
+                   const std::string& shell_port,
+                   const std::string& stdin_port,
+                   xserver_zmq_split* server)
+        : m_shell(context, zmq::socket_type::router)
+        , m_stdin(context, zmq::socket_type::router)
+        , m_publisher_pub(context, zmq::socket_type::pub)
+        , m_controller(context, zmq::socket_type::rep)
+        , p_server(server)
+    {
+        init_socket(m_shell, transport, ip, shell_port);
+        init_socket(m_stdin, transport, ip, stdin_port);
+        m_publisher_pub.setsockopt(ZMQ_LINGER, get_socket_linger());
+        m_publisher_pub.connect(get_publisher_end_point());
+
+        m_controller.setsockopt(ZMQ_LINGER, get_socket_linger());
+        m_controller.bind(get_controller_end_point("shell"));
+    }
+
+    xshell::~xshell()
+    {
+    }
+
+    std::string xshell::get_shell_port() const
+    {
+        return get_socket_port(m_shell);
+    }
+
+    std::string xshell::get_stdin_port() const
+    {
+        return get_socket_port(m_stdin);
+    }
+
+    void xshell::run()
+    {
+        zmq::pollitem_t items[] = {
+            { m_shell, 0, ZMQ_POLLIN, 0 },
+            { m_controller, 0, ZMQ_POLLIN, 0 }
+        };
+
+        while (true)
+        {
+            zmq::poll(&items[0], 2, -1);
+
+            if (items[0].revents & ZMQ_POLLIN)
+            {
+                zmq::multipart_t wire_msg;
+                wire_msg.recv(m_shell);
+                p_server->notify_shell_listener(wire_msg);
+            }
+
+            if (items[1].revents & ZMQ_POLLIN)
+            {
+                // stop message
+                zmq::multipart_t wire_msg;
+                wire_msg.recv(m_controller);
+                wire_msg.send(m_controller);
+                break;
+            }
+        }
+    }
+
+    void xshell::send_shell(zmq::multipart_t& message)
+    {
+        message.send(m_shell);
+    }
+
+    void xshell::send_stdin(zmq::multipart_t& message)
+    {
+        message.send(m_stdin);
+        zmq::multipart_t wire_msg;
+        wire_msg.recv(m_stdin);
+        p_server->notify_stdin_listener(wire_msg);
+    }
+
+    void xshell::publish(zmq::multipart_t& message)
+    {
+        message.send(m_publisher_pub);
+    }
+
+    void xshell::abort_queue(const listener& l, long polling_interval)
+    {
+        while (true)
+        {
+            zmq::multipart_t wire_msg;
+            bool msg = wire_msg.recv(m_shell, ZMQ_NOBLOCK);
+            if (!msg)
+            {
+                return;
+            }
+
+            l(wire_msg);
+            std::this_thread::sleep_for(std::chrono::milliseconds(polling_interval));
+        }
+    }
+}
+

--- a/src/xshell.hpp
+++ b/src/xshell.hpp
@@ -1,0 +1,52 @@
+/***************************************************************************
+* Copyright (c) 2018, Johan Mabille, Sylvain Corlay and Martin Renou       *
+*                                                                          *
+* Distributed under the terms of the BSD 3-Clause License.                 *
+*                                                                          *
+* The full license is in the file LICENSE, distributed with this software. *
+****************************************************************************/
+
+#include <string>
+
+#include "zmq.hpp"
+#include "zmq_addon.hpp"
+
+namespace xeus
+{
+    class xserver_zmq_split;
+
+    class xshell
+    {
+    public:
+
+        using listener = std::function<void(zmq::multipart_t&)>;
+
+        xshell(zmq::context_t& context,
+               const std::string& transport,
+               const std::string& ip,
+               const std::string& shell_port,
+               const std::string& sdtin_port,
+               xserver_zmq_split* server);
+
+        ~xshell();
+
+        std::string get_shell_port() const;
+        std::string get_stdin_port() const;
+
+        void run();
+
+        void send_shell(zmq::multipart_t& message);
+        void send_stdin(zmq::multipart_t& message);
+        void publish(zmq::multipart_t& message);
+        void abort_queue(const listener& l, long polling_interval);
+
+    private:
+
+        zmq::socket_t m_shell;
+        zmq::socket_t m_stdin;
+        zmq::socket_t m_publisher_pub;
+        zmq::socket_t m_controller;
+        xserver_zmq_split* p_server;
+    };
+}
+

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -158,3 +158,30 @@ add_custom_command(
 add_custom_command(
     TARGET test_kernel POST_BUILD
     COMMAND ${CMAKE_COMMAND} -E copy "${XEUS_TEST_DIR}/test_kernel.py" "${CMAKE_CURRENT_BINARY_DIR}/")
+
+# Test_kernel_split tests
+# =======================
+
+set(TEST_KERNEL_SPLIT_SOURCES
+    test_interpreter.cpp
+    test_interpreter.hpp
+    main_split.cpp)
+
+configure_file(
+    "${XEUS_TEST_DIR}/test_kernel_split/kernel.json.in"
+    "${XEUS_TEST_DIR}/test_kernel_split/kernel.json"
+)
+
+add_executable(test_kernel_split ${TEST_KERNEL_SPLIT_SOURCES})
+target_link_libraries(test_kernel_split ${xeus_TARGET} Threads::Threads)
+
+target_compile_features(test_kernel_split PRIVATE cxx_std_11)
+
+set(CONNECTION_FILE ${CMAKE_CURRENT_SOURCE_DIR}/connection.json)
+
+add_custom_command(
+    TARGET test_kernel_split POST_BUILD
+    COMMAND jupyter-kernelspec install "${XEUS_TEST_DIR}/test_kernel_split" --sys-prefix)
+add_custom_command(
+    TARGET test_kernel_split POST_BUILD
+    COMMAND ${CMAKE_COMMAND} -E copy "${XEUS_TEST_DIR}/test_kernel_split.py" "${CMAKE_CURRENT_BINARY_DIR}/")

--- a/test/main_split.cpp
+++ b/test/main_split.cpp
@@ -1,0 +1,42 @@
+/***************************************************************************
+* Copyright (c) 2016, Johan Mabille and Sylvain Corlay                     *
+*                                                                          *
+* Distributed under the terms of the BSD 3-Clause License.                 *
+*                                                                          *
+* The full license is in the file LICENSE, distributed with this software. *
+****************************************************************************/
+
+#include <iostream>
+#include <memory>
+
+#include "test_interpreter.hpp"
+#include "xeus/xkernel.hpp"
+#include "xeus/xkernel_configuration.hpp"
+#include "xeus/xserver_zmq_split.hpp"
+
+std::unique_ptr<xeus::xserver> make_xserver_split(zmq::context_t& context, const xeus::xconfiguration& config)
+{
+    return std::make_unique<xeus::xserver_zmq_split>(context, config);
+}
+
+int main(int argc, char* argv[])
+{
+    std::string file_name = (argc == 1) ? "connection.json" : argv[2];
+    xeus::xconfiguration config = xeus::load_configuration(file_name);
+
+    using history_manager_ptr = std::unique_ptr<xeus::xhistory_manager>;
+    history_manager_ptr hist = history_manager_ptr(new xeus::xin_memory_history_manager());
+    
+    using interpreter_ptr = std::unique_ptr<test_kernel::test_interpreter>;
+    interpreter_ptr interpreter = interpreter_ptr(new test_kernel::test_interpreter());
+    
+    xeus::xkernel kernel(config,
+                         xeus::get_user_name(),
+                         std::move(interpreter),
+                         std::move(hist),
+                         make_xserver_split);
+    std::cout << "starting kernel" << std::endl;
+    kernel.start();
+
+    return 0;
+}

--- a/test/test_kernel_split.py
+++ b/test/test_kernel_split.py
@@ -1,0 +1,36 @@
+import unittest
+import jupyter_kernel_test
+
+
+class XeusKernelTests(jupyter_kernel_test.KernelTests):
+
+    kernel_name = "test_kernel_split"
+    language_name = "cpp"
+
+    code_hello_world = "hello, world"
+    code_page_something = "?"
+
+    code_execute_result = [
+        {'code': '6*7', 'result': '6*7'},
+        {'code': 'test', 'result': 'test'}
+    ]
+
+    completion_samples = [
+        {'text': 'a.', 'matches': ['a.test1', 'a.test2']}
+    ]
+
+    complete_code_samples = ["complete"]
+    incomplete_code_samples = ["incomplete"]
+    invalid_code_samples = ["invalid"]
+
+    code_inspect_sample = "invalid"
+
+    def test_xeus_stderr(self):
+        reply, output_msgs = self.execute_helper(code='error')
+        self.assertEqual(output_msgs[0]['msg_type'], 'stream')
+        self.assertEqual(output_msgs[0]['content']['name'], 'stderr')
+        self.assertEqual(output_msgs[0]['content']['text'], 'error')
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/test/test_kernel_split/kernel.json
+++ b/test/test_kernel_split/kernel.json
@@ -1,0 +1,9 @@
+{
+    "display_name": "test_kernel",
+    "language" : "cpp",
+    "argv": [
+        "/home/yoyo/dev/quantstack/xeus/build/test/test_kernel_split",
+        "-f",
+        "{connection_file}"
+    ]
+}

--- a/test/test_kernel_split/kernel.json.in
+++ b/test/test_kernel_split/kernel.json.in
@@ -1,0 +1,9 @@
+{
+    "display_name": "test_kernel",
+    "language" : "cpp",
+    "argv": [
+        "@CMAKE_BINARY_DIR@/test/test_kernel_split",
+        "-f",
+        "{connection_file}"
+    ]
+}


### PR DESCRIPTION
This PR adds a new server implementation where the Shell and the Controller are different threads. This is a requirement for having debuggers in Jupyter kernel.

@jcfr You might be interested in this. I'm pretty sure the new server implementation does not suit you needs yet, the `poll` function is not available in the new server implementation. We could make one, however this one would control the "controller" (i.e. main) thread only, not the  `shell` thread, which is now run in a dedicated loop. I guess that you would prefer to have control over the `shell` thread loop?

Also notice that this implementation is an alternative to the existing one, not a replacement; we might replace the default implementation of the `make_server` function in the future (so it returns the new server implementation), but the `xserver_zmq` class will remain.