### PR TITLE
Improve tests with more CMake

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -38,7 +38,4 @@ install:
   - cd ..\..\build
 
 build_script:
-  - .\test\test_xeus
-  - "set JUPYTER_PATH=%CD%\\test"
-  - py.test test\test_kernel.py
-  - py.test test\test_kernel_control.py
+  - nmake test

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -39,5 +39,6 @@ install:
 
 build_script:
   - .\test\test_xeus
+  - "set JUPYTER_PATH=%CD%\\test"
   - py.test test\test_kernel.py
   - py.test test\test_kernel_control.py

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -38,4 +38,4 @@ install:
   - cd ..\..\build
 
 build_script:
-  - nmake test
+  - ctest --output-on-failure

--- a/.gitignore
+++ b/.gitignore
@@ -40,9 +40,6 @@ test/Makefile
 test/CMakeFiles/
 test/__pycache__/
 test/cmake_install.cmake
-test/test_kernel/kernel.json
-test/test_kernel_control/kernel.json
-test/test_kernel_shell/kernel.json
 
 # Documentation build artefacts
 docs/CMakeCache.txt

--- a/.travis.yml
+++ b/.travis.yml
@@ -55,5 +55,5 @@ install:
 script:
     - cd test
     - ./test_xeus
-    - py.test test_kernel.py
-    - py.test test_kernel_control.py
+    - JUPYTER_PATH=$PWD py.test test_kernel.py
+    - JUPYTER_PATH=$PWD py.test test_kernel_control.py

--- a/.travis.yml
+++ b/.travis.yml
@@ -53,4 +53,4 @@ install:
     - popd && popd
     - cd build
 script:
-    - make test
+    - ctest --output-on-failure

--- a/.travis.yml
+++ b/.travis.yml
@@ -53,7 +53,4 @@ install:
     - popd && popd
     - cd build
 script:
-    - cd test
-    - ./test_xeus
-    - JUPYTER_PATH=$PWD py.test test_kernel.py
-    - JUPYTER_PATH=$PWD py.test test_kernel_control.py
+    - make test

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -301,14 +301,14 @@ endif ()
 # Tests
 # =====
 
-OPTION(BUILD_TESTS "xeus test suite" OFF)
+include(CTest)
 OPTION(DOWNLOAD_GTEST "build gtest from downloaded sources" OFF)
 
 if(DOWNLOAD_GTEST OR GTEST_SRC_DIR)
-    set(BUILD_TESTS ON)
+    set(BUILD_TESTING ON)
 endif()
 
-if(BUILD_TESTS)
+if(BUILD_TESTING)
     add_subdirectory(test)
 endif()
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -141,9 +141,9 @@ set(TEST_KERNEL_SOURCES
     test_interpreter.hpp
     main.cpp)
 
-configure_file (
+configure_file(
     "${XEUS_TEST_DIR}/test_kernel/kernel.json.in"
-    "${XEUS_TEST_DIR}/test_kernel/kernel.json"
+    "kernels/test_kernel/kernel.json"
 )
 
 add_executable(test_kernel ${TEST_KERNEL_SOURCES})
@@ -153,9 +153,6 @@ target_compile_features(test_kernel PRIVATE cxx_std_11)
 
 set(CONNECTION_FILE ${CMAKE_CURRENT_SOURCE_DIR}/connection.json)
 
-add_custom_command(
-    TARGET test_kernel POST_BUILD
-    COMMAND jupyter-kernelspec install "${XEUS_TEST_DIR}/test_kernel" --sys-prefix)
 add_custom_command(
     TARGET test_kernel POST_BUILD
     COMMAND ${CMAKE_COMMAND} -E copy "${XEUS_TEST_DIR}/test_kernel.py" "${CMAKE_CURRENT_BINARY_DIR}/")
@@ -170,7 +167,7 @@ set(TEST_KERNEL_SPLIT_SOURCES
 
 configure_file(
     "${XEUS_TEST_DIR}/test_kernel_control/kernel.json.in"
-    "${XEUS_TEST_DIR}/test_kernel_control/kernel.json"
+    "kernels/test_kernel_control/kernel.json"
 )
 
 add_executable(test_kernel_control ${TEST_KERNEL_SPLIT_SOURCES})
@@ -180,9 +177,6 @@ target_compile_features(test_kernel_control PRIVATE cxx_std_11)
 
 set(CONNECTION_FILE ${CMAKE_CURRENT_SOURCE_DIR}/connection.json)
 
-add_custom_command(
-    TARGET test_kernel_control POST_BUILD
-    COMMAND jupyter-kernelspec install "${XEUS_TEST_DIR}/test_kernel_control" --sys-prefix)
 add_custom_command(
     TARGET test_kernel_control POST_BUILD
     COMMAND ${CMAKE_COMMAND} -E copy "${XEUS_TEST_DIR}/test_kernel_control.py" "${CMAKE_CURRENT_BINARY_DIR}/")
@@ -197,7 +191,7 @@ set(TEST_KERNEL_SPLIT_SOURCES
 
 configure_file(
     "${XEUS_TEST_DIR}/test_kernel_shell/kernel.json.in"
-    "${XEUS_TEST_DIR}/test_kernel_shell/kernel.json"
+    "kernels/test_kernel_shell/kernel.json"
 )
 
 add_executable(test_kernel_shell ${TEST_KERNEL_SPLIT_SOURCES})
@@ -207,9 +201,6 @@ target_compile_features(test_kernel_shell PRIVATE cxx_std_11)
 
 set(CONNECTION_FILE ${CMAKE_CURRENT_SOURCE_DIR}/connection.json)
 
-add_custom_command(
-    TARGET test_kernel_shell POST_BUILD
-    COMMAND jupyter-kernelspec install "${XEUS_TEST_DIR}/test_kernel_shell" --sys-prefix)
 add_custom_command(
     TARGET test_kernel_shell POST_BUILD
     COMMAND ${CMAKE_COMMAND} -E copy "${XEUS_TEST_DIR}/test_kernel_shell.py" "${CMAKE_CURRENT_BINARY_DIR}/")

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -118,23 +118,21 @@ foreach(filename IN LISTS XEUS_TESTS)
     add_test(NAME ${targetname} COMMAND ${targetname})
 endforeach()
 
-add_executable(test_xeus ${XEUS_TESTS} ${XEUS_HEADERS})
 if(DOWNLOAD_GTEST OR GTEST_SRC_DIR)
-    add_dependencies(test_xeus gtest_main)
-
     # https://github.com/QuantStack/xeus/pull/126
+    # This should really just be post gtest and gtest_main targets, but CMake
+    # won't allow us to do that. So do it after the last test (which depends on
+    # those anyway.)
     if (BUILD_SHARED_LIBS)
         add_custom_command(
-            TARGET test_xeus POST_BUILD
+            TARGET ${targetname} POST_BUILD
             COMMAND ${CMAKE_COMMAND} -E copy "$<TARGET_FILE:gtest>" "${CMAKE_CURRENT_BINARY_DIR}/")
+
         add_custom_command(
-            TARGET test_xeus POST_BUILD
+            TARGET ${targetname} POST_BUILD
             COMMAND ${CMAKE_COMMAND} -E copy "$<TARGET_FILE:gtest_main>" "${CMAKE_CURRENT_BINARY_DIR}/")
     endif ()
 endif()
-target_link_libraries(test_xeus ${xeus_TARGET} ${GTEST_BOTH_LIBRARIES} Threads::Threads ${nlohmann_json_TARGET})
-
-add_custom_target(xtest COMMAND test_xeus DEPENDS test_xeus)
 
 # Test_kernel tests
 # =================

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -153,9 +153,10 @@ target_compile_features(test_kernel PRIVATE cxx_std_11)
 
 set(CONNECTION_FILE ${CMAKE_CURRENT_SOURCE_DIR}/connection.json)
 
-add_custom_command(
-    TARGET test_kernel POST_BUILD
-    COMMAND ${CMAKE_COMMAND} -E copy "${XEUS_TEST_DIR}/test_kernel.py" "${CMAKE_CURRENT_BINARY_DIR}/")
+configure_file(
+    "${XEUS_TEST_DIR}/test_kernel.py"
+    "${CMAKE_CURRENT_BINARY_DIR}/"
+    COPYONLY)
 
 # Test_kernel_control tests
 # =========================
@@ -177,9 +178,10 @@ target_compile_features(test_kernel_control PRIVATE cxx_std_11)
 
 set(CONNECTION_FILE ${CMAKE_CURRENT_SOURCE_DIR}/connection.json)
 
-add_custom_command(
-    TARGET test_kernel_control POST_BUILD
-    COMMAND ${CMAKE_COMMAND} -E copy "${XEUS_TEST_DIR}/test_kernel_control.py" "${CMAKE_CURRENT_BINARY_DIR}/")
+configure_file(
+    "${XEUS_TEST_DIR}/test_kernel_control.py"
+    "${CMAKE_CURRENT_BINARY_DIR}/"
+    COPYONLY)
 
 # Test_kernel_shell tests
 # =======================
@@ -201,6 +203,7 @@ target_compile_features(test_kernel_shell PRIVATE cxx_std_11)
 
 set(CONNECTION_FILE ${CMAKE_CURRENT_SOURCE_DIR}/connection.json)
 
-add_custom_command(
-    TARGET test_kernel_shell POST_BUILD
-    COMMAND ${CMAKE_COMMAND} -E copy "${XEUS_TEST_DIR}/test_kernel_shell.py" "${CMAKE_CURRENT_BINARY_DIR}/")
+configure_file(
+    "${XEUS_TEST_DIR}/test_kernel_shell.py"
+    "${CMAKE_CURRENT_BINARY_DIR}/"
+    COPYONLY)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -81,6 +81,9 @@ endif()
 
 find_package(Threads)
 
+find_program(PYTEST
+    NAMES pytest-3 pytest py.test-3 py.test)
+
 include_directories(${GTEST_INCLUDE_DIRS})
 
 set(XEUS_TESTS
@@ -158,6 +161,12 @@ configure_file(
     "${CMAKE_CURRENT_BINARY_DIR}/"
     COPYONLY)
 
+add_test(NAME test_kernel
+    COMMAND ${PYTEST} test_kernel.py)
+set_tests_properties(test_kernel
+    PROPERTIES
+    ENVIRONMENT "JUPYTER_PATH=${CMAKE_CURRENT_BINARY_DIR}")
+
 # Test_kernel_control tests
 # =========================
 
@@ -183,6 +192,12 @@ configure_file(
     "${CMAKE_CURRENT_BINARY_DIR}/"
     COPYONLY)
 
+add_test(NAME test_kernel_control
+    COMMAND ${PYTEST} test_kernel_control.py)
+set_tests_properties(test_kernel_control
+    PROPERTIES
+    ENVIRONMENT "JUPYTER_PATH=${CMAKE_CURRENT_BINARY_DIR}")
+
 # Test_kernel_shell tests
 # =======================
 
@@ -207,3 +222,9 @@ configure_file(
     "${XEUS_TEST_DIR}/test_kernel_shell.py"
     "${CMAKE_CURRENT_BINARY_DIR}/"
     COPYONLY)
+
+add_test(NAME test_kernel_shell
+    COMMAND ${PYTEST} test_kernel_shell.py)
+set_tests_properties(test_kernel_shell
+    PROPERTIES
+    ENVIRONMENT "JUPYTER_PATH=${CMAKE_CURRENT_BINARY_DIR}")


### PR DESCRIPTION
Improves testing by moving more things into CMake:
* The builtin CTest has its own `option()`, so use that instead of `BUILD_TESTS`, and it also enables `add_test` to do something.
* Using CTest means that `ctest` or `make test` can be used to run tests, so also `add_test` for the Jupyter kernel tests, and then switch CI to use it for consistency.
* This also adds `test_kernel_shell` to CTest, since it seems to have been forgotten in CI config. Placing everything in `CMakeLists.txt` like this will avoid that sort of thing happening in the future.
* Use `JUPYTER_PATH` environment variable to setup the test kernels, meaning they don't need to be installed globally any more.

If I missed anything, see commit messages.