### PR TITLE
Don't set _any_ options if DISABLE_ARCH_NATIVE=ON.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -236,9 +236,7 @@ macro(xeus_create_target target_name linkage output_name)
 
         target_compile_options(${target_name} PUBLIC -Wunused-parameter -Wextra -Wreorder)
 
-        if (DISABLE_ARCH_NATIVE)
-            target_compile_options(${target_name} PUBLIC -mtune=generic)
-        else ()
+	if (NOT DISABLE_ARCH_NATIVE)
             target_compile_options(${target_name} PUBLIC -march=native)
         endif ()
 


### PR DESCRIPTION
On some platforms (e.g., [s390x](https://koji.fedoraproject.org/koji/taskinfo?taskID=37522402)), even `-mtune=generic` is not allowed, so just don't pass anything.